### PR TITLE
test: Run GitHub Code scanning with high severity issue

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -34,7 +34,7 @@ jobs:
           output: results.sarif
           format: sarif
           # Adjust severity of non-security issues
-          gh-code-scanning-compat: true
+          # gh-code-scanning-compat: true
           # Force 0 exit code to allow SARIF file generation
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
@@ -45,7 +45,7 @@ jobs:
         with:
           sarif_file: results.sarif
 
-      - name: Archive code coverage results
+      - name: Archive results
         uses: actions/upload-artifact@v2
         with:
           name: output-results-sarif

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -34,7 +34,7 @@ jobs:
           output: results.sarif
           format: sarif
           # Adjust severity of non-security issues
-          # gh-code-scanning-compat: true
+          gh-code-scanning-compat: true
           # Force 0 exit code to allow SARIF file generation
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -44,3 +44,9 @@ jobs:
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: results.sarif
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v2
+        with:
+          name: output-results-sarif
+          path: results.sarif

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -34,7 +34,7 @@ jobs:
           output: results.sarif
           format: sarif
           # Adjust severity of non-security issues
-          gh-code-scanning-compat: true
+          # gh-code-scanning-compat: true
           # Force 0 exit code to allow SARIF file generation
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647

--- a/foo.py
+++ b/foo.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import random
+import telnetlib
 
 a = hashlib.sha1(str(random.getrandbits(256)))
 


### PR DESCRIPTION
It's possible to set checks reported by each individual tool as "Required" in [branch protection rules](https://github.com/pauloribeiro-codacy/sandbox/settings/branch_protection_rules/18036644). However, only issues of severity `Error` make the check fail and I'm having trouble triggering an issue of this level.

For example, when I run Bandit locally it detects a high severity security issue, but [it's being reported](https://github.com/pauloribeiro-codacy/sandbox/pull/8/checks?check_run_id=1786368179) as `Warning` on GitHub Code scanning. Could this be a bug, perhaps on the GitHub side? :thinking: 

```bash
$ bandit foo.py 
[...]
Run started:2021-01-28 18:13:44.494243

Test results:
>> Issue: [B401:blacklist] A telnet-related module is being imported.  Telnet is considered insecure. Use SSH or some other encrypted protocol.
   Severity: High   Confidence: High
   Location: foo.py:5
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b401-import-telnetlib
4	import random
5	import telnetlib
6
[...]
```

More info on [code scanning results on pull requests](https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/triaging-code-scanning-alerts-in-pull-requests#about-code-scanning-results-on-pull-requests):

> If code scanning has any results with a severity of `error`, the check fails and the error is reported in the check results. If all the results found by code scanning have lower severities, the alerts are treated as warnings or notices and the check succeeds. If your pull request targets a protected branch that has been enabled for code scanning, and the repository owner has configured required status checks, then you must either fix or dismiss all error alerts before the pull request can be merged.